### PR TITLE
Update PayPal Android SDK to 2.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 PayPal Cordova Plugin Release Notes
 ===================================
+TODO
+-----
+* Android: Minor bug fixes.
+* Android: Updated gradle version to 2.14.
+* Android: Include `org.json.*` exceptions in default proguard file [#299](https://github.com/paypal/PayPal-Android-SDK/issues/299).
+
 
 3.2.1
 -----
+* Android: Minor bug fixes.
+* Android: Updated gradle version to 2.14.
+* Android: Include `org.json.*` exceptions in default proguard file [#299](https://github.com/paypal/PayPal-Android-SDK/issues/299).
+
 * Android: Update card.io to 5.4.0.
 * Android: Update okhttp dependency to 3.3.1.
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-   compile('com.paypal.sdk:paypal-android-sdk:2.14.3') {
+   compile('com.paypal.sdk:paypal-android-sdk:2.14.4') {
       exclude group: 'io.card'
    }
 }


### PR DESCRIPTION
* Minor bug fixes.
* Updated gradle version to 2.14.
* Include `org.json.*` exceptions in default proguard file [#299](https://github.com/paypal/PayPal-Android-SDK/issues/299).