### PR TITLE
Update PayPal iOS SDK to 2.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 PayPal Cordova Plugin Release Notes
 ===================================
+TODO
+-----
+* iOS: Update localized messages.
+* iOS: Fix issue with truncated text in certain table cells. See [issue #367](https://github.com/paypal/PayPal-iOS-SDK/issues/367).
+
 3.2.2
 -----
+* iOS: Update localized messages.
+* iOS: Fix issue with truncated text in certain table cells. See [issue #367](https://github.com/paypal/PayPal-iOS-SDK/issues/367).
+
 * Android: Minor bug fixes.
 * Android: Updated gradle version to 2.14.
 * Android: Include `org.json.*` exceptions in default proguard file [#299](https://github.com/paypal/PayPal-Android-SDK/issues/299).
 
 3.2.1
 -----
+* iOS: Update localized messages.
+* iOS: Fix issue with truncated text in certain table cells. See [issue #367](https://github.com/paypal/PayPal-iOS-SDK/issues/367).
+
 * Android: Update card.io to 5.4.0.
 * Android: Update okhttp dependency to 3.3.1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,24 @@ TODO
 -----
 * iOS: Update localized messages.
 * iOS: Fix issue with truncated text in certain table cells. See [issue #367](https://github.com/paypal/PayPal-iOS-SDK/issues/367).
+* iOS: Change layout for 1Password icon to be in the email/phone field. See [issue #405](https://github.com/paypal/PayPal-iOS-SDK/issues/405)
+* iOS: Allow configuration option to disable shake animations for accessibility.
+  See [issue #380](https://github.com/paypal/PayPal-iOS-SDK/issues/380)
+  See `PayPalConfiguration disableShakeAnimations` option
+* iOS: Fix issue with missing 1Password data.
+  See [issue #427](https://github.com/paypal/PayPal-iOS-SDK/issues/427)
+* iOS: Fix issue with network request timeouts
+* iOS: Update card.io to iOS 5.3.2
+* iOS: Fix missing nullability headers See issue #404
 
 3.2.2
 -----
-* iOS: Update localized messages.
-* iOS: Fix issue with truncated text in certain table cells. See [issue #367](https://github.com/paypal/PayPal-iOS-SDK/issues/367).
-
 * Android: Minor bug fixes.
 * Android: Updated gradle version to 2.14.
 * Android: Include `org.json.*` exceptions in default proguard file [#299](https://github.com/paypal/PayPal-Android-SDK/issues/299).
 
 3.2.1
 -----
-* iOS: Update localized messages.
-* iOS: Fix issue with truncated text in certain table cells. See [issue #367](https://github.com/paypal/PayPal-iOS-SDK/issues/367).
-
 * Android: Update card.io to 5.4.0.
 * Android: Update okhttp dependency to 3.3.1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,8 @@ TODO
 * iOS: Update localized messages.
 * iOS: Fix issue with truncated text in certain table cells. See [issue #367](https://github.com/paypal/PayPal-iOS-SDK/issues/367).
 * iOS: Change layout for 1Password icon to be in the email/phone field. See [issue #405](https://github.com/paypal/PayPal-iOS-SDK/issues/405)
-* iOS: Allow configuration option to disable shake animations for accessibility.
-  See [issue #380](https://github.com/paypal/PayPal-iOS-SDK/issues/380)
-  See `PayPalConfiguration disableShakeAnimations` option
-* iOS: Fix issue with missing 1Password data.
-  See [issue #427](https://github.com/paypal/PayPal-iOS-SDK/issues/427)
+* iOS: Allow configuration option to disable shake animations for accessibility. See [issue #380](https://github.com/paypal/PayPal-iOS-SDK/issues/380). See `PayPalConfiguration disableShakeAnimations` option.
+* iOS: Fix issue with missing 1Password data. See [issue #427](https://github.com/paypal/PayPal-iOS-SDK/issues/427).
 * iOS: Fix issue with network request timeouts
 * iOS: Update card.io to iOS 5.3.2
 * iOS: Fix missing nullability headers See issue #404

--- a/src/ios/PayPalMobile/PayPalConfiguration.h
+++ b/src/ios/PayPalMobile/PayPalConfiguration.h
@@ -1,7 +1,7 @@
 //
 //  PayPalConfiguration.h
 //
-//  Version 2.14.0
+//  Version 2.14.4
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.
@@ -110,6 +110,10 @@ typedef NS_ENUM(NSInteger, PayPalShippingAddressOption) {
 /// If you will present the SDK's view controller within a popover, then set this property to YES.
 /// Defaults to NO.
 @property(nonatomic, assign, readwrite) BOOL presentingInPopover;
+
+/// If you would prefer to use dialog boxes instead of shake animations.
+/// Defaults to NO.
+@property(nonatomic, assign, readwrite) BOOL disableShakeAnimations;
 
 /// Sandbox credentials can be difficult to type on a mobile device. Setting this flag to YES will
 /// cause the sandboxUserPassword and sandboxUserPin to always be pre-populated into login fields.

--- a/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalFuturePaymentViewController.h
 //
-//  Version 2.14.0
+//  Version 2.14.4
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.
@@ -62,6 +62,6 @@ typedef void (^PayPalFuturePaymentDelegateCompletionBlock)(void);
                                       delegate:(nullable id<PayPalFuturePaymentDelegate>)delegate;
 
 /// Delegate access
-@property (nonatomic, weak, readonly) id<PayPalFuturePaymentDelegate> futurePaymentDelegate;
+@property (nonatomic, weak, readonly, nullable) id<PayPalFuturePaymentDelegate> futurePaymentDelegate;
 
 @end

--- a/src/ios/PayPalMobile/PayPalMobile.h
+++ b/src/ios/PayPalMobile/PayPalMobile.h
@@ -1,7 +1,7 @@
 //
 //  PayPalMobile.h
 //
-//  Version 2.14.0
+//  Version 2.14.4
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalOAuthScopes.h
+++ b/src/ios/PayPalMobile/PayPalOAuthScopes.h
@@ -1,7 +1,7 @@
 //
 //  PayPalOAuthScopes.h
 //
-//  Version 2.14.0
+//  Version 2.14.4
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalPayment.h
+++ b/src/ios/PayPalMobile/PayPalPayment.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPayment.h
 //
-//  Version 2.14.0
+//  Version 2.14.4
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalPaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalPaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPaymentViewController.h
 //
-//  Version 2.14.0
+//  Version 2.14.4
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.
@@ -78,7 +78,7 @@ typedef void (^PayPalPaymentDelegateCompletionBlock)(void);
                                 delegate:(nonnull id<PayPalPaymentDelegate>)delegate;
 
 /// Delegate access
-@property(nonatomic, weak, readonly) id<PayPalPaymentDelegate> paymentDelegate;
+@property(nonatomic, weak, readonly, nullable) id<PayPalPaymentDelegate> paymentDelegate;
 
 /// PayPalPaymentViewControllerState See the state property for context.
 typedef NS_ENUM(NSInteger, PayPalPaymentViewControllerState) {

--- a/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
+++ b/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalProfileSharingViewController.h
 //
-//  Version 2.14.0
+//  Version 2.14.4
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.
@@ -65,6 +65,6 @@ typedef void (^PayPalProfileSharingDelegateCompletionBlock)(void);
                                     delegate:(nullable id<PayPalProfileSharingDelegate>)delegate;
 
 /// Delegate access
-@property (nonatomic, weak, readonly) id<PayPalProfileSharingDelegate> profileSharingDelegate;
+@property (nonatomic, weak, readonly, nullable) id<PayPalProfileSharingDelegate> profileSharingDelegate;
 
 @end


### PR DESCRIPTION
* Update localized messages.
* Fix issue with truncated text in certain table cells. See [issue #367](https://github.com/paypal/PayPal-iOS-SDK/issues/367).