### PR TITLE
Update PayPal iOS SDK to 2.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@ PayPal Cordova Plugin Release Notes
 ===================================
 TODO
 -----
+* iOS: Fix issue with localization not being correctly looked up [#449](https://github.com/paypal/PayPal-iOS-SDK/issues/449).
+  For iOS 9, the SDK will use the best matching language based on `NSBundle.preferredLocalizationsFromArray` and what
+  is translated in the SDK.
+* iOS: If you use card.io to scan credit cards, you should add the key
+  [`NSCameraUsageDescription`](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
+  to your app's `Info.plist` and set the value to be a string describing why your app needs to use the camera
+  (e.g. "To scan credit cards."). This string will be displayed when the app initially requests permission to access
+  the camera.
+
+TODO
+-----
+* iOS: Fix issue with localization not being correctly looked up [#449](https://github.com/paypal/PayPal-iOS-SDK/issues/449).
+  For iOS 9, the SDK will use the best matching language based on `NSBundle.preferredLocalizationsFromArray` and what
+  is translated in the SDK.
+* iOS: If you use card.io to scan credit cards, you should add the key
+  [`NSCameraUsageDescription`](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
+  to your app's `Info.plist` and set the value to be a string describing why your app needs to use the camera
+  (e.g. "To scan credit cards."). This string will be displayed when the app initially requests permission to access
+  the camera.
+
+-----
+* iOS: Fix issue with localization not being correctly looked up [#449](https://github.com/paypal/PayPal-iOS-SDK/issues/449).
+  For iOS 9, the SDK will use the best matching language based on `NSBundle.preferredLocalizationsFromArray` and what
+  is translated in the SDK.
+* iOS: If you use card.io to scan credit cards, you should add the key
+  [`NSCameraUsageDescription`](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
+  to your app's `Info.plist` and set the value to be a string describing why your app needs to use the camera
+  (e.g. "To scan credit cards."). This string will be displayed when the app initially requests permission to access
+  the camera.
+
 * iOS: Fix issue with Bitcode when archiving [#443](https://github.com/paypal/PayPal-iOS-SDK/issues/443).
 * iOS: If you use card.io to scan credit cards, you should add the key
   [`NSCameraUsageDescription`](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
@@ -10,6 +40,15 @@ TODO
   the camera.
 
 -----
+* iOS: Fix issue with localization not being correctly looked up [#449](https://github.com/paypal/PayPal-iOS-SDK/issues/449).
+  For iOS 9, the SDK will use the best matching language based on `NSBundle.preferredLocalizationsFromArray` and what
+  is translated in the SDK.
+* iOS: If you use card.io to scan credit cards, you should add the key
+  [`NSCameraUsageDescription`](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
+  to your app's `Info.plist` and set the value to be a string describing why your app needs to use the camera
+  (e.g. "To scan credit cards."). This string will be displayed when the app initially requests permission to access
+  the camera.
+
 
 * iOS: Update localized messages.
 * iOS: Fix issue with truncated text in certain table cells. See [issue #367](https://github.com/paypal/PayPal-iOS-SDK/issues/367).
@@ -22,12 +61,30 @@ TODO
 
 3.2.2
 -----
+* iOS: Fix issue with localization not being correctly looked up [#449](https://github.com/paypal/PayPal-iOS-SDK/issues/449).
+  For iOS 9, the SDK will use the best matching language based on `NSBundle.preferredLocalizationsFromArray` and what
+  is translated in the SDK.
+* iOS: If you use card.io to scan credit cards, you should add the key
+  [`NSCameraUsageDescription`](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
+  to your app's `Info.plist` and set the value to be a string describing why your app needs to use the camera
+  (e.g. "To scan credit cards."). This string will be displayed when the app initially requests permission to access
+  the camera.
+
 * Android: Minor bug fixes.
 * Android: Updated gradle version to 2.14.
 * Android: Include `org.json.*` exceptions in default proguard file [#299](https://github.com/paypal/PayPal-Android-SDK/issues/299).
 
 3.2.1
 -----
+* iOS: Fix issue with localization not being correctly looked up [#449](https://github.com/paypal/PayPal-iOS-SDK/issues/449).
+  For iOS 9, the SDK will use the best matching language based on `NSBundle.preferredLocalizationsFromArray` and what
+  is translated in the SDK.
+* iOS: If you use card.io to scan credit cards, you should add the key
+  [`NSCameraUsageDescription`](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
+  to your app's `Info.plist` and set the value to be a string describing why your app needs to use the camera
+  (e.g. "To scan credit cards."). This string will be displayed when the app initially requests permission to access
+  the camera.
+
 * Android: Update card.io to 5.4.0.
 * Android: Update okhttp dependency to 3.3.1.
 

--- a/src/ios/PayPalMobile/PayPalConfiguration.h
+++ b/src/ios/PayPalMobile/PayPalConfiguration.h
@@ -1,7 +1,7 @@
 //
 //  PayPalConfiguration.h
 //
-//  Version 2.14.5
+//  Version 2.14.6
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalFuturePaymentViewController.h
 //
-//  Version 2.14.5
+//  Version 2.14.6
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalMobile.h
+++ b/src/ios/PayPalMobile/PayPalMobile.h
@@ -1,7 +1,7 @@
 //
 //  PayPalMobile.h
 //
-//  Version 2.14.5
+//  Version 2.14.6
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalOAuthScopes.h
+++ b/src/ios/PayPalMobile/PayPalOAuthScopes.h
@@ -1,7 +1,7 @@
 //
 //  PayPalOAuthScopes.h
 //
-//  Version 2.14.5
+//  Version 2.14.6
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalPayment.h
+++ b/src/ios/PayPalMobile/PayPalPayment.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPayment.h
 //
-//  Version 2.14.5
+//  Version 2.14.6
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalPaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalPaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPaymentViewController.h
 //
-//  Version 2.14.5
+//  Version 2.14.6
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
+++ b/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalProfileSharingViewController.h
 //
-//  Version 2.14.5
+//  Version 2.14.6
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.


### PR DESCRIPTION
* Fix issue with localization not being correctly looked up [#449](https://github.com/paypal/PayPal-iOS-SDK/issues/449).
  For iOS 9, the SDK will use the best matching language based on `NSBundle.preferredLocalizationsFromArray` and what
  is translated in the SDK.
* If you use card.io to scan credit cards, you should add the key
  [`NSCameraUsageDescription`](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
  to your app's `Info.plist` and set the value to be a string describing why your app needs to use the camera
  (e.g. "To scan credit cards."). This string will be displayed when the app initially requests permission to access
  the camera.