### PR TITLE
Add payeeEmail field

### DIFF
--- a/src/android/PayPalMobileCordovaPlugin.java
+++ b/src/android/PayPalMobileCordovaPlugin.java
@@ -176,6 +176,12 @@ public class PayPalMobileCordovaPlugin extends CordovaPlugin {
         }
 
         // optional
+        String payeeEmail = null;
+        if (paymentObject.has("payeeEmail") && !paymentObject.isNull("payeeEmail")) {
+            payeeEmail = paymentObject.getString("payeeEmail");
+        }
+
+        // optional
         String bnCode = null;
         if (paymentObject.has("bnCode") && !paymentObject.isNull("bnCode")) {
             bnCode = paymentObject.getString("bnCode");
@@ -198,6 +204,7 @@ public class PayPalMobileCordovaPlugin extends CordovaPlugin {
         payment.invoiceNumber(invoiceNumber);
         payment.custom(custom);
         payment.softDescriptor(softDescriptor);
+        payment.payeeEmail(payeeEmail);
         payment.bnCode(bnCode);
         payment.paymentDetails(this.parsePaymentDetails(paymentDetails));
         payment.items(this.parsePaymentItems(items));

--- a/src/ios/PayPalMobileCordovaPlugin.m
+++ b/src/ios/PayPalMobileCordovaPlugin.m
@@ -100,6 +100,7 @@
     NSString *invoiceNumber = payment[@"invoiceNumber"];
     NSString *custom = payment[@"custom"];
     NSString *softDescriptor = payment[@"softDescriptor"];
+    NSString *payeeEmail = payment[@"payeeEmail"];
     NSString *bnCode = payment[@"bnCode"];
     NSArray *items = payment[@"items"];
     NSDictionary *shippingAddress = payment[@"shippingAddress"];
@@ -121,6 +122,7 @@
     ppPayment.invoiceNumber = invoiceNumber;
     ppPayment.custom = custom;
     ppPayment.softDescriptor = softDescriptor;
+    ppPayment.payeeEmail = payeeEmail;
     ppPayment.bnCode = bnCode;
     ppPayment.items = [self getPayPalItemsFromJSArray:items];
     ppPayment.shippingAddress = [self getPayPalShippingAddressFromDictionary:shippingAddress];

--- a/www/paypal-mobile-js-helper.js
+++ b/www/paypal-mobile-js-helper.js
@@ -97,6 +97,14 @@ PayPalPayment.prototype.items = function(items) {
 };
 
 /**
+ * Optional payee email, if your app is paying a third-party merchant.
+ * @param {String} payeeEmail: The payee's email. It must be a valid PayPal email address.
+ */
+PayPalPayment.prototype.payeeEmail = function(payeeEmail) {
+  this.payeeEmail = payeeEmail;
+};
+
+/**
  * Optional customer shipping address, if your app wishes to provide this to the SDK.
  * @note make sure to set `payPalShippingAddressOption` in PayPalConfiguration to 1 or 3.
  * @param {Object} shippingAddress: PayPalShippingAddress object


### PR DESCRIPTION
Exposes the `payeeEmail` field for both Android and iOS. ~~Needs #226 and #230~~. Fixes #231 .

Still needs testing.
