### PR TITLE
Update PayPal Android SDK to 2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ PayPal Cordova Plugin Release Notes
 ===================================
 TODO
 -----
+* Android: Removed trustall trustmanager to resolve google play security issue [#364](https://github.com/paypal/PayPal-Android-SDK/issues/364).
+* Android: Shows amount properly in all devices [#357](https://github.com/paypal/PayPal-Android-SDK/issues/357).
+
+TODO
+-----
 * iOS: Improve network code reliability.
 
 TODO

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-   compile('com.paypal.sdk:paypal-android-sdk:2.15.0') {
+   compile('com.paypal.sdk:paypal-android-sdk:2.15.1') {
       exclude group: 'io.card'
    }
 }


### PR DESCRIPTION
* Removed trustall trustmanager to resolve google play security issue [#364](https://github.com/paypal/PayPal-Android-SDK/issues/364).
* Shows amount properly in all devices [#357](https://github.com/paypal/PayPal-Android-SDK/issues/357).