### PR TITLE
Update PayPal Android SDK to 2.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ PayPal Cordova Plugin Release Notes
 ===================================
 TODO
 -----
+* Android: Add mandatory res folder in aar during release [#383](https://github.com/paypal/PayPal-Android-SDK/issues/383).
+* Android: Updated card.io to 5.5.0.
+* Android: Updated okhttp to 3.6.0.
+
+TODO
+-----
 * Android: Removed trustall trustmanager to resolve google play security issue [#364](https://github.com/paypal/PayPal-Android-SDK/issues/364).
 * Android: Shows amount properly in all devices [#357](https://github.com/paypal/PayPal-Android-SDK/issues/357).
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-   compile('com.paypal.sdk:paypal-android-sdk:2.15.1') {
+   compile('com.paypal.sdk:paypal-android-sdk:2.15.2') {
       exclude group: 'io.card'
    }
 }


### PR DESCRIPTION
* Add mandatory res folder in aar during release [#383](https://github.com/paypal/PayPal-Android-SDK/issues/383).
* Updated card.io to 5.5.0.
* Updated okhttp to 3.6.0.