### PR TITLE
Update PayPal iOS SDK to 2.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 PayPal Cordova Plugin Release Notes
 ===================================
+TODO
+-----
+* iOS: Fix issue with parsing API responses [#508](https://github.com/paypal/PayPal-iOS-SDK/issues/508).
+
 
 3.4.0
 -----

--- a/src/ios/PayPalMobile/PayPalConfiguration.h
+++ b/src/ios/PayPalMobile/PayPalConfiguration.h
@@ -1,7 +1,7 @@
 //
 //  PayPalConfiguration.h
 //
-//  Version 2.16.1
+//  Version 2.16.3
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalFuturePaymentViewController.h
 //
-//  Version 2.16.1
+//  Version 2.16.3
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalMobile.h
+++ b/src/ios/PayPalMobile/PayPalMobile.h
@@ -1,7 +1,7 @@
 //
 //  PayPalMobile.h
 //
-//  Version 2.16.1
+//  Version 2.16.3
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalOAuthScopes.h
+++ b/src/ios/PayPalMobile/PayPalOAuthScopes.h
@@ -1,7 +1,7 @@
 //
 //  PayPalOAuthScopes.h
 //
-//  Version 2.16.1
+//  Version 2.16.3
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalPayment.h
+++ b/src/ios/PayPalMobile/PayPalPayment.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPayment.h
 //
-//  Version 2.16.1
+//  Version 2.16.3
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalPaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalPaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPaymentViewController.h
 //
-//  Version 2.16.1
+//  Version 2.16.3
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
+++ b/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalProfileSharingViewController.h
 //
-//  Version 2.16.1
+//  Version 2.16.3
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.


### PR DESCRIPTION
* Fix issue with parsing API responses [#508](https://github.com/paypal/PayPal-iOS-SDK/issues/508).