### PR TITLE
Update PayPal iOS SDK to 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ PayPal Cordova Plugin Release Notes
 ===================================
 TODO
 -----
+* iOS: Add documentation to use string initializer for NSDecimalNumber [#520](https://github.com/paypal/PayPal-iOS-SDK/issues/520).
+* iOS: Fix issue with potential `data parameter is nil` when decoding JSON [#523](https://github.com/paypal/PayPal-iOS-SDK/issues/523).
+* iOS: iOS version 6.1 is no longer supported by this SDK.
+
+TODO
+-----
 * iOS: Fix issue with parsing API responses [#508](https://github.com/paypal/PayPal-iOS-SDK/issues/508).
 
 

--- a/src/ios/PayPalMobile/PayPalConfiguration.h
+++ b/src/ios/PayPalMobile/PayPalConfiguration.h
@@ -1,7 +1,7 @@
 //
 //  PayPalConfiguration.h
 //
-//  Version 2.16.3
+//  Version 2.17.0
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalFuturePaymentViewController.h
 //
-//  Version 2.16.3
+//  Version 2.17.0
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalMobile.h
+++ b/src/ios/PayPalMobile/PayPalMobile.h
@@ -1,7 +1,7 @@
 //
 //  PayPalMobile.h
 //
-//  Version 2.16.3
+//  Version 2.17.0
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalOAuthScopes.h
+++ b/src/ios/PayPalMobile/PayPalOAuthScopes.h
@@ -1,7 +1,7 @@
 //
 //  PayPalOAuthScopes.h
 //
-//  Version 2.16.3
+//  Version 2.17.0
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalPayment.h
+++ b/src/ios/PayPalMobile/PayPalPayment.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPayment.h
 //
-//  Version 2.16.3
+//  Version 2.17.0
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSInteger, PayPalPaymentIntent) {
 /// @see https://developer.paypal.com/webapps/developer/docs/api/#details-object for more details.
 @interface PayPalPaymentDetails : NSObject <NSCopying>
 
-/// Convenience constructor.
+/// Convenience constructor. NSDecimalNumber parameters must be initialized using a string value.
 /// See the documentation of the individual properties for more detail.
 /// @param subtotal Sum of amounts for all items in this transaction.
 /// @param shipping Shipping and handling amount for the overall transaction.
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSInteger, PayPalPaymentIntent) {
 /// @see https://developer.paypal.com/docs/api/#item-object for more details.
 @interface PayPalItem : NSObject <NSCopying>
 
-/// Convenience constructor.
+/// Convenience constructor. NSDecimalNumber parameters must be initialized using a string value.
 /// See the documentation of the individual properties for more detail.
 /// @param name Name of the item.
 /// @param quantity Number of units.
@@ -138,7 +138,7 @@ typedef NS_ENUM(NSInteger, PayPalPaymentIntent) {
 
 @interface PayPalPayment : NSObject <NSCopying>
 
-/// Convenience constructor.
+/// Convenience constructor. NSDecimalNumber parameters must be initialized using a string value.
 /// See the documentation of the individual properties for more detail.
 /// @param amount The amount of the payment.
 /// @param currencyCode The ISO 4217 currency for the payment.

--- a/src/ios/PayPalMobile/PayPalPaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalPaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPaymentViewController.h
 //
-//  Version 2.16.3
+//  Version 2.17.0
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
+++ b/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalProfileSharingViewController.h
 //
-//  Version 2.16.3
+//  Version 2.17.0
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.


### PR DESCRIPTION
* Add documentation to use string initializer for NSDecimalNumber [#520](https://github.com/paypal/PayPal-iOS-SDK/issues/520).
* Fix issue with potential `data parameter is nil` when decoding JSON [#523](https://github.com/paypal/PayPal-iOS-SDK/issues/523).
* iOS version 6.1 is no longer supported by this SDK.