### PR TITLE
Update PayPal iOS SDK to 2.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ PayPal Cordova Plugin Release Notes
 ===================================
 TODO
 -----
+* iOS: PayPal Mobile SDKs are Deprecated and only existing integrations are supported. For all new integrations, use [Braintree Direct](https://www.braintreepayments.com/products/braintree-direct) in [supported countries](https://www.braintreepayments.com/country-selection). In other countries, use [Express Checkout](https://developer.paypal.com/docs/accept-payments/express-checkout/ec-braintree-sdk/get-started/) and choose the Braintree SDK integration option.
+* iOS: Update translations.
+* iOS: Compiled with Xcode 9.2.
+
+TODO
+-----
 * iOS: Fix text field first responder animation issue in iOS 11 [#548](https://github.com/paypal/PayPal-iOS-SDK/issues/548).
 * iOS: Fix memory retain issue cycle during initialization [#538](https://github.com/paypal/PayPal-iOS-SDK/issues/538).
 

--- a/src/ios/PayPalMobile/PayPalConfiguration.h
+++ b/src/ios/PayPalMobile/PayPalConfiguration.h
@@ -1,7 +1,7 @@
 //
 //  PayPalConfiguration.h
 //
-//  Version 2.18.0
+//  Version 2.18.1
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalFuturePaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalFuturePaymentViewController.h
 //
-//  Version 2.18.0
+//  Version 2.18.1
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalMobile.h
+++ b/src/ios/PayPalMobile/PayPalMobile.h
@@ -1,7 +1,7 @@
 //
 //  PayPalMobile.h
 //
-//  Version 2.18.0
+//  Version 2.18.1
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalOAuthScopes.h
+++ b/src/ios/PayPalMobile/PayPalOAuthScopes.h
@@ -1,7 +1,7 @@
 //
 //  PayPalOAuthScopes.h
 //
-//  Version 2.18.0
+//  Version 2.18.1
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalPayment.h
+++ b/src/ios/PayPalMobile/PayPalPayment.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPayment.h
 //
-//  Version 2.18.0
+//  Version 2.18.1
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalPaymentViewController.h
+++ b/src/ios/PayPalMobile/PayPalPaymentViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalPaymentViewController.h
 //
-//  Version 2.18.0
+//  Version 2.18.1
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.

--- a/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
+++ b/src/ios/PayPalMobile/PayPalProfileSharingViewController.h
@@ -1,7 +1,7 @@
 //
 //  PayPalProfileSharingViewController.h
 //
-//  Version 2.18.0
+//  Version 2.18.1
 //
 //  Copyright (c) 2014-2016 PayPal, Inc. All rights reserved.
 //  All rights reserved.


### PR DESCRIPTION
* PayPal Mobile SDKs are Deprecated and only existing integrations are supported. For all new integrations, use [Braintree Direct](https://www.braintreepayments.com/products/braintree-direct) in [supported countries](https://www.braintreepayments.com/country-selection). In other countries, use [Express Checkout](https://developer.paypal.com/docs/accept-payments/express-checkout/ec-braintree-sdk/get-started/) and choose the Braintree SDK integration option.
* Update translations.
* Compiled with Xcode 9.2.